### PR TITLE
Improve Chinese friction gate UX

### DIFF
--- a/app/src/main/java/net/kollnig/reddblockandroid/ui/screen/FrictionGateScreen.kt
+++ b/app/src/main/java/net/kollnig/reddblockandroid/ui/screen/FrictionGateScreen.kt
@@ -289,21 +289,21 @@ fun FrictionGateScreen(
                                     verticalArrangement = Arrangement.spacedBy(4.dp)
                                 ) {
                                     Text(
-                                        cw.character,
+                                        cw.pinyin,
                                         style = MaterialTheme.typography.displaySmall,
                                         fontWeight = FontWeight.Bold,
                                         textAlign = TextAlign.Center,
                                         color = IndigoPrimary
                                     )
                                     Text(
-                                        cw.pinyin,
+                                        cw.meaning,
                                         style = MaterialTheme.typography.titleMedium,
                                         fontWeight = FontWeight.SemiBold,
                                         textAlign = TextAlign.Center,
-                                        color = IndigoPrimary
+                                        color = MaterialTheme.colorScheme.onSurface
                                     )
                                     Text(
-                                        cw.meaning,
+                                        cw.character,
                                         style = MaterialTheme.typography.bodyMedium,
                                         textAlign = TextAlign.Center,
                                         color = MaterialTheme.colorScheme.onSurfaceVariant

--- a/app/src/main/java/net/kollnig/reddblockandroid/ui/screen/FrictionGateScreen.kt
+++ b/app/src/main/java/net/kollnig/reddblockandroid/ui/screen/FrictionGateScreen.kt
@@ -104,6 +104,7 @@ fun FrictionGateScreen(
     var currentWordIndex by remember { mutableIntStateOf(0) }
     var userInput by remember { mutableStateOf("") }
     var isError by remember { mutableStateOf(false) }
+    var pinyinRevealed by remember { mutableStateOf(false) }
     val focusRequester = remember { FocusRequester() }
     val keyboardController = LocalSoftwareKeyboardController.current
 
@@ -137,6 +138,7 @@ fun FrictionGateScreen(
             } else {
                 currentWordIndex++
                 userInput = ""
+                pinyinRevealed = false
             }
         } else {
             isError = true
@@ -289,18 +291,11 @@ fun FrictionGateScreen(
                                     verticalArrangement = Arrangement.spacedBy(4.dp)
                                 ) {
                                     Text(
-                                        cw.pinyin,
+                                        cw.meaning,
                                         style = MaterialTheme.typography.displaySmall,
                                         fontWeight = FontWeight.Bold,
                                         textAlign = TextAlign.Center,
                                         color = IndigoPrimary
-                                    )
-                                    Text(
-                                        cw.meaning,
-                                        style = MaterialTheme.typography.titleMedium,
-                                        fontWeight = FontWeight.SemiBold,
-                                        textAlign = TextAlign.Center,
-                                        color = MaterialTheme.colorScheme.onSurface
                                     )
                                     Text(
                                         cw.character,
@@ -308,6 +303,19 @@ fun FrictionGateScreen(
                                         textAlign = TextAlign.Center,
                                         color = MaterialTheme.colorScheme.onSurfaceVariant
                                     )
+                                    if (pinyinRevealed) {
+                                        Text(
+                                            cw.pinyin,
+                                            style = MaterialTheme.typography.titleMedium,
+                                            fontWeight = FontWeight.SemiBold,
+                                            textAlign = TextAlign.Center,
+                                            color = IndigoPrimary
+                                        )
+                                    } else {
+                                        TextButton(onClick = { pinyinRevealed = true }) {
+                                            Text(stringResource(R.string.friction_gate_reveal_pinyin))
+                                        }
+                                    }
                                     IconButton(onClick = {
                                         tts?.speak(cw.character, TextToSpeech.QUEUE_FLUSH, null, null)
                                     }) {

--- a/app/src/main/java/net/kollnig/reddblockandroid/ui/screen/FrictionGateScreen.kt
+++ b/app/src/main/java/net/kollnig/reddblockandroid/ui/screen/FrictionGateScreen.kt
@@ -121,11 +121,12 @@ fun FrictionGateScreen(
     fun normalizeUserPinyin(input: String): String =
         java.text.Normalizer.normalize(input.trim().lowercase(), java.text.Normalizer.Form.NFD)
             .replace(Regex("[\\p{InCombiningDiacriticalMarks}]"), "")
-            .replace(Regex("\\s+"), "")
+            .replace(Regex("[^a-z]"), "")
 
     fun checkWord() {
         val isCorrect = if (useChineseMode) {
-            normalizeUserPinyin(userInput) == chineseWords[currentWordIndex].pinyinNormalized
+            val expected = chineseWords[currentWordIndex].pinyinNormalized.replace(Regex("[^a-z]"), "")
+            normalizeUserPinyin(userInput) == expected
         } else {
             userInput.trim().equals(words[currentWordIndex], ignoreCase = true)
         }
@@ -291,6 +292,13 @@ fun FrictionGateScreen(
                                         cw.character,
                                         style = MaterialTheme.typography.displaySmall,
                                         fontWeight = FontWeight.Bold,
+                                        textAlign = TextAlign.Center,
+                                        color = IndigoPrimary
+                                    )
+                                    Text(
+                                        cw.pinyin,
+                                        style = MaterialTheme.typography.titleMedium,
+                                        fontWeight = FontWeight.SemiBold,
                                         textAlign = TextAlign.Center,
                                         color = IndigoPrimary
                                     )

--- a/app/src/main/java/net/kollnig/reddblockandroid/ui/screen/FrictionGateScreen.kt
+++ b/app/src/main/java/net/kollnig/reddblockandroid/ui/screen/FrictionGateScreen.kt
@@ -357,7 +357,7 @@ fun FrictionGateScreen(
                             keyboardOptions = KeyboardOptions(
                                 imeAction = ImeAction.Done,
                                 autoCorrectEnabled = false,
-                                keyboardType = if (useChineseMode) KeyboardType.Text else KeyboardType.Password
+                                keyboardType = KeyboardType.Password
                             ),
                             keyboardActions = KeyboardActions(onDone = { checkWord() }),
                             colors = OutlinedTextFieldDefaults.colors(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,6 +86,7 @@
     <string name="friction_gate_error">That doesn\'t match. Try again.</string>
     <string name="friction_gate_error_chinese">Incorrect. The pinyin is: %s</string>
     <string name="friction_gate_pinyin_hint">Type the pinyin\u2026</string>
+    <string name="friction_gate_reveal_pinyin">Reveal pinyin</string>
     <string name="friction_gate_next">Next</string>
     <string name="friction_gate_finish">Finish</string>
 


### PR DESCRIPTION
## Summary
- Switch the pinyin input field to `KeyboardType.Password` so the IME no longer offers word completions that pollute the user's English dictionary.
- Strip non-letter characters (apostrophes, etc.) from both user input and the stored pinyin during comparison so words like 女儿 (`nǚ'ér`) match whether or not the user types the apostrophe.
- Restructure the word card: the English meaning is now front and center, with the Chinese character shown as a small reference. The pinyin sits behind a "Reveal pinyin" button that resets on each new word.

## Test plan
- [ ] Enter the friction gate in Chinese mode; confirm keyboard shows no word suggestions.
- [ ] Verify typing `nuer` matches 女儿 and `keai` matches 可爱 (with or without apostrophe).
- [ ] Confirm the meaning is the most prominent element, the character is a small reference line, and pinyin appears only after tapping "Reveal pinyin".
- [ ] Advance to the next word and confirm the pinyin is hidden again.