### PR TITLE
Enhance Chinese friction gate: reveal pinyin on wrong, weekly stats

### DIFF
--- a/app/src/main/java/net/kollnig/reddblockandroid/ui/screen/FrictionGateScreen.kt
+++ b/app/src/main/java/net/kollnig/reddblockandroid/ui/screen/FrictionGateScreen.kt
@@ -105,7 +105,7 @@ fun FrictionGateScreen(
     var currentWordIndex by remember { mutableIntStateOf(0) }
     var userInput by remember { mutableStateOf("") }
     var isError by remember { mutableStateOf(false) }
-    var pinyinRevealed by remember { mutableStateOf(false) }
+    var pinyinManuallyRevealed by remember { mutableStateOf(false) }
     var wordStartMillis by remember { mutableStateOf(System.currentTimeMillis()) }
     var weeklyStats by remember { mutableStateOf(ChineseTypingStats.getWeeklyStats()) }
     val focusRequester = remember { FocusRequester() }
@@ -145,12 +145,11 @@ fun FrictionGateScreen(
             } else {
                 currentWordIndex++
                 userInput = ""
-                pinyinRevealed = false
+                pinyinManuallyRevealed = false
                 wordStartMillis = System.currentTimeMillis()
             }
         } else {
             isError = true
-            if (useChineseMode) pinyinRevealed = true
         }
     }
 
@@ -312,7 +311,7 @@ fun FrictionGateScreen(
                                         textAlign = TextAlign.Center,
                                         color = MaterialTheme.colorScheme.onSurfaceVariant
                                     )
-                                    if (pinyinRevealed) {
+                                    if (isError || pinyinManuallyRevealed) {
                                         Text(
                                             cw.pinyin,
                                             style = MaterialTheme.typography.titleMedium,
@@ -321,7 +320,7 @@ fun FrictionGateScreen(
                                             color = IndigoPrimary
                                         )
                                     } else {
-                                        TextButton(onClick = { pinyinRevealed = true }) {
+                                        TextButton(onClick = { pinyinManuallyRevealed = true }) {
                                             Text(stringResource(R.string.friction_gate_reveal_pinyin))
                                         }
                                     }
@@ -369,11 +368,6 @@ fun FrictionGateScreen(
                             shape = RoundedCornerShape(10.dp),
                             singleLine = true,
                             isError = isError,
-                            supportingText = if (isError) {
-                                {
-                                    Text(stringResource(R.string.friction_gate_error))
-                                }
-                            } else null,
                             keyboardOptions = KeyboardOptions(
                                 imeAction = ImeAction.Done,
                                 autoCorrectEnabled = false,

--- a/app/src/main/java/net/kollnig/reddblockandroid/ui/screen/FrictionGateScreen.kt
+++ b/app/src/main/java/net/kollnig/reddblockandroid/ui/screen/FrictionGateScreen.kt
@@ -31,6 +31,7 @@ import net.kollnig.reddblockandroid.BuildConfig
 import net.kollnig.reddblockandroid.R
 import net.kollnig.reddblockandroid.data.CHINESE_VOCABULARY
 import net.kollnig.reddblockandroid.ui.theme.*
+import net.kollnig.reddblockandroid.util.ChineseTypingStats
 
 // Common English words for the friction gate
 private val WORD_LIST = listOf(
@@ -105,6 +106,8 @@ fun FrictionGateScreen(
     var userInput by remember { mutableStateOf("") }
     var isError by remember { mutableStateOf(false) }
     var pinyinRevealed by remember { mutableStateOf(false) }
+    var wordStartMillis by remember { mutableStateOf(System.currentTimeMillis()) }
+    var weeklyStats by remember { mutableStateOf(ChineseTypingStats.getWeeklyStats()) }
     val focusRequester = remember { FocusRequester() }
     val keyboardController = LocalSoftwareKeyboardController.current
 
@@ -133,15 +136,21 @@ fun FrictionGateScreen(
         }
         if (isCorrect) {
             isError = false
+            if (useChineseMode) {
+                ChineseTypingStats.recordWord(System.currentTimeMillis() - wordStartMillis)
+                weeklyStats = ChineseTypingStats.getWeeklyStats()
+            }
             if (currentWordIndex >= totalCount - 1) {
                 onPassed()
             } else {
                 currentWordIndex++
                 userInput = ""
                 pinyinRevealed = false
+                wordStartMillis = System.currentTimeMillis()
             }
         } else {
             isError = true
+            if (useChineseMode) pinyinRevealed = true
         }
     }
 
@@ -362,12 +371,7 @@ fun FrictionGateScreen(
                             isError = isError,
                             supportingText = if (isError) {
                                 {
-                                    Text(
-                                        if (useChineseMode)
-                                            stringResource(R.string.friction_gate_error_chinese, chineseWords[currentWordIndex].pinyin)
-                                        else
-                                            stringResource(R.string.friction_gate_error)
-                                    )
+                                    Text(stringResource(R.string.friction_gate_error))
                                 }
                             } else null,
                             keyboardOptions = KeyboardOptions(
@@ -420,6 +424,21 @@ fun FrictionGateScreen(
                             }
                         }
                     }
+                }
+
+                if (useChineseMode) {
+                    val minutes = (weeklyStats.totalDurationMs / 60_000L).toInt()
+                    Text(
+                        text = stringResource(
+                            R.string.friction_gate_weekly_stats,
+                            weeklyStats.wordCount,
+                            minutes
+                        ),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.fillMaxWidth()
+                    )
                 }
 
                 Spacer(Modifier.height(32.dp))

--- a/app/src/main/java/net/kollnig/reddblockandroid/util/ChineseTypingStats.kt
+++ b/app/src/main/java/net/kollnig/reddblockandroid/util/ChineseTypingStats.kt
@@ -1,0 +1,48 @@
+package net.kollnig.reddblockandroid.util
+
+import androidx.core.content.edit
+import org.json.JSONArray
+import org.json.JSONObject
+
+object ChineseTypingStats {
+    private const val KEY = "chinese_typing_events"
+    private const val WEEK_MS = 7L * 24 * 60 * 60 * 1000
+
+    data class WeeklyStats(val wordCount: Int, val totalDurationMs: Long)
+
+    fun recordWord(durationMs: Long) {
+        if (!isPrefsInitialized) return
+        val cutoff = System.currentTimeMillis() - WEEK_MS
+        val arr = readArray().prune(cutoff)
+        arr.put(JSONObject().apply {
+            put("t", System.currentTimeMillis())
+            put("d", durationMs.coerceAtLeast(0))
+        })
+        prefs.edit { putString(KEY, arr.toString()) }
+    }
+
+    fun getWeeklyStats(): WeeklyStats {
+        if (!isPrefsInitialized) return WeeklyStats(0, 0)
+        val cutoff = System.currentTimeMillis() - WEEK_MS
+        val arr = readArray().prune(cutoff)
+        var total = 0L
+        for (i in 0 until arr.length()) {
+            total += arr.getJSONObject(i).optLong("d", 0)
+        }
+        return WeeklyStats(arr.length(), total)
+    }
+
+    private fun readArray(): JSONArray {
+        val raw = prefs.getString(KEY, "[]") ?: "[]"
+        return try { JSONArray(raw) } catch (_: Exception) { JSONArray() }
+    }
+
+    private fun JSONArray.prune(cutoff: Long): JSONArray {
+        val out = JSONArray()
+        for (i in 0 until length()) {
+            val o = optJSONObject(i) ?: continue
+            if (o.optLong("t", 0) >= cutoff) out.put(o)
+        }
+        return out
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,11 +84,11 @@
     <string name="block_gate_instruction">Blocked by your \"%1$s\" schedule. To unlock, type the following:</string>
     <string name="friction_gate_input_label">Type the word above</string>
     <string name="friction_gate_error">That doesn\'t match. Try again.</string>
-    <string name="friction_gate_error_chinese">Incorrect. The pinyin is: %s</string>
     <string name="friction_gate_pinyin_hint">Type the pinyin\u2026</string>
     <string name="friction_gate_reveal_pinyin">Reveal pinyin</string>
     <string name="friction_gate_next">Next</string>
     <string name="friction_gate_finish">Finish</string>
+    <string name="friction_gate_weekly_stats">This week: %1$d words \u00b7 ~%2$d min typing</string>
 
     <!-- Permissions Screen -->
     <string name="permissions_info">These permissions are needed for ReDD Block to function properly.</string>


### PR DESCRIPTION
- On a wrong pinyin attempt, auto-reveal the pinyin above instead of
  displaying the correct answer in the supporting text below the input.
- Track each completed character and the time spent on it, persisted in
  shared prefs, pruned to the past 7 days.
- Show a small weekly summary below the card: number of words typed and
  an estimated minutes of typing time.

https://claude.ai/code/session_011NHTZEZ85t8dtGg4nVfWYt