### PR TITLE
Fix friction gate cancel for blocked websites and browser app

### DIFF
--- a/app/src/main/java/net/kollnig/reddblockandroid/UnlockActivity.kt
+++ b/app/src/main/java/net/kollnig/reddblockandroid/UnlockActivity.kt
@@ -21,6 +21,7 @@ class UnlockActivity : ComponentActivity() {
         const val EXTRA_SCHEDULE_ID = "schedule_id"
         const val EXTRA_SCHEDULE_NAME = "schedule_name"
         const val EXTRA_BLOCKED_TARGET = "blocked_target"
+        const val EXTRA_IS_WEBSITE = "is_website"
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -30,6 +31,7 @@ class UnlockActivity : ComponentActivity() {
         val scheduleId = intent.getStringExtra(EXTRA_SCHEDULE_ID)
         val scheduleName = intent.getStringExtra(EXTRA_SCHEDULE_NAME)
         val blockedTarget = intent.getStringExtra(EXTRA_BLOCKED_TARGET)
+        val isWebsite = intent.getBooleanExtra(EXTRA_IS_WEBSITE, false)
         val schedule = scheduleId?.let { Schedules.get(it) }
 
         if (schedule == null || !schedule.isEnabled) {
@@ -52,10 +54,18 @@ class UnlockActivity : ComponentActivity() {
                         finish()
                     },
                     onBackPressed = {
-                        // In block mode, go home instead of back to the blocked app.
-                        // Finish so this gate doesn't linger in its task and resurface
-                        // when the user later relaunches the app from the launcher.
-                        goHomeAndFinish()
+                        if (isWebsite) {
+                            // The browser has already been redirected to the focus
+                            // page (reddfocus.org). Just finish so Android returns to
+                            // it, rather than kicking the user out to the home screen.
+                            finish()
+                        } else {
+                            // For blocked apps, returning to them would immediately
+                            // re-trigger the gate. Go home instead, and finish so this
+                            // gate doesn't linger in its task and resurface when the
+                            // user later relaunches the app from the launcher.
+                            goHomeAndFinish()
+                        }
                     }
                 )
             }

--- a/app/src/main/java/net/kollnig/reddblockandroid/service/BlockerService.kt
+++ b/app/src/main/java/net/kollnig/reddblockandroid/service/BlockerService.kt
@@ -41,8 +41,11 @@ class BlockerService : AccessibilityService() {
         val pkg = event.packageName?.toString() ?: return
         if (pkg == packageName) return
 
-        // Check for website blocking in supported browsers
-        if (isSupportedBrowser(pkg)) {
+        // Check for website blocking in supported browsers.
+        // If the browser app itself is blocked, skip URL-based website handling
+        // so the whole browser is gated as an app (go home on cancel) rather than
+        // redirected to the reddfocus.org focus page like a single blocked site.
+        if (isSupportedBrowser(pkg) && Schedules.findBlockingScheduleForApp(pkg) == null) {
             val currentTime = System.currentTimeMillis()
             if (currentTime - lastUrlCheckTime >= URL_CHECK_THROTTLE_MS) {
                 val url = extractUrlFromEvent(event)
@@ -56,7 +59,7 @@ class BlockerService : AccessibilityService() {
                             if (blockingSchedule != null) {
                                 Log.d(TAG, "Blocking website $domain in browser ($pkg)")
                                 navigateBrowserToBlank(pkg)
-                                launchFrictionGate(blockingSchedule.id, blockingSchedule.name, domain)
+                                launchFrictionGate(blockingSchedule.id, blockingSchedule.name, domain, isWebsite = true)
                                 return
                             }
                         }
@@ -76,16 +79,22 @@ class BlockerService : AccessibilityService() {
                 lastBlockedTime = now
                 Log.d(TAG, "Blocking app $pkg by schedule: $blockingSchedule")
                 val appLabel = getAppLabel(pkg)
-                launchFrictionGate(blockingSchedule.id, blockingSchedule.name, appLabel)
+                launchFrictionGate(blockingSchedule.id, blockingSchedule.name, appLabel, isWebsite = false)
             }
         }
     }
 
-    private fun launchFrictionGate(scheduleId: String, scheduleName: String, blockedTarget: String) {
+    private fun launchFrictionGate(
+        scheduleId: String,
+        scheduleName: String,
+        blockedTarget: String,
+        isWebsite: Boolean
+    ) {
         val intent = Intent(this, UnlockActivity::class.java).apply {
             putExtra(UnlockActivity.EXTRA_SCHEDULE_ID, scheduleId)
             putExtra(UnlockActivity.EXTRA_SCHEDULE_NAME, scheduleName)
             putExtra(UnlockActivity.EXTRA_BLOCKED_TARGET, blockedTarget)
+            putExtra(UnlockActivity.EXTRA_IS_WEBSITE, isWebsite)
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         }
         startActivity(intent)


### PR DESCRIPTION
## Problem

Isolating the friction gate into its own task (`e69edce`) introduced two regressions around the browser:

1. **Cancelling a blocked-website gate went to the home screen.** Previously the browser was redirected to the `reddfocus.org` focus page and cancel returned there. After the change, cancel force-navigated to the Android home screen (`goHomeAndFinish()`), so the user never saw `reddfocus.org` and the browser felt fully blocked.

2. **Blocking the browser *app* could still redirect to `reddfocus.org`.** The website-detection branch runs first for any supported browser, so if the browser loaded a page whose domain was also blocked (e.g. the default "Social Media" schedule blocks both social apps and social domains), the website flow won and redirected to `reddfocus.org` — even though the whole browser was meant to be gated as an app.

## Fix

- Pass an `is_website` flag from `BlockerService` to `UnlockActivity`. On cancel: **website** blocks `finish()` back to the browser (showing `reddfocus.org`); **app** blocks keep `goHomeAndFinish()`, since returning to a blocked app would immediately re-trigger the gate.
- Skip website URL handling when the browser **app itself** is blocked, so it falls through to app-block handling (gate → home, no `reddfocus.org` redirect).

## Resulting behavior

- Website blocked (browser app allowed) → redirect to `reddfocus.org`, cancel returns to the browser on that page.
- Browser app blocked → app gate, cancel goes home, no `reddfocus.org`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)